### PR TITLE
Fix macOs windows question screen

### DIFF
--- a/meals_app/lib/main.dart
+++ b/meals_app/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-
 import 'package:google_fonts/google_fonts.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:meals_app/screens/tabs.dart';
 
@@ -15,7 +15,9 @@ final theme = ThemeData(
 
 void main() {
   runApp(
-    const App(),
+    const ProviderScope(
+      child: App(),
+    ),
   );
 }
 
@@ -25,9 +27,8 @@ class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      theme: theme,
-      home: const TabsScreen()
-    );
+        debugShowCheckedModeBanner: false,
+        theme: theme,
+        home: const TabsScreen());
   }
 }

--- a/meals_app/lib/providers/favorites_provider.dart
+++ b/meals_app/lib/providers/favorites_provider.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:meals_app/models/meal.dart';
+
+class FavoriteNotifier extends StateNotifier<List<Meal>> {
+  FavoriteNotifier() : super([]);
+
+  void toggleMealFavoriteStatus(Meal meal) {
+    final mealIsFavorite = state.contains(meal);
+
+    if (mealIsFavorite) {
+      state = state.where((m) => m.id != meal.id).toList();
+    } else {
+      state = [...state, meal];
+    }
+  }
+}
+
+final favoritesProvider = StateNotifierProvider<FavoriteNotifier, List<Meal>>(
+  (ref) {
+    return FavoriteNotifier();
+  },
+);

--- a/meals_app/lib/providers/meals_provider.dart
+++ b/meals_app/lib/providers/meals_provider.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:meals_app/data/dummy_data.dart';
+
+final mealsProvider = Provider((ref) {
+  return dummyMeals;
+});

--- a/meals_app/lib/screens/tabs.dart
+++ b/meals_app/lib/screens/tabs.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:meals_app/data/dummy_data.dart';
-import 'package:meals_app/models/meal.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:meals_app/models/meal.dart';
+import 'package:meals_app/providers/meals_provider.dart';
 import 'package:meals_app/screens/categories.dart';
 import 'package:meals_app/screens/filters.dart';
 import 'package:meals_app/screens/meals.dart';
@@ -14,16 +15,16 @@ const kInitialFilters = {
     Filter.vegan: false,
   };
 
-class TabsScreen extends StatefulWidget {
+class TabsScreen extends ConsumerStatefulWidget {
   const TabsScreen({super.key});
 
   @override
-  State<StatefulWidget> createState() {
+  ConsumerState<ConsumerStatefulWidget> createState() {
     return _TabsScreenState();
   }
 }
 
-class _TabsScreenState extends State<TabsScreen> {
+class _TabsScreenState extends ConsumerState<TabsScreen> {
   int _selectedPageIndex = 0;
   final List<Meal> _favoriteMeals = [];
   Map<Filter, bool> _selectedFilters = kInitialFilters;
@@ -74,7 +75,9 @@ class _TabsScreenState extends State<TabsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final availableMeals = dummyMeals.where((meal) {
+    final meals = ref.watch(mealsProvider);
+
+    final availableMeals = meals.where((meal) {
       if (_selectedFilters[Filter.glutenFree]! && !meal.isGlutenFree){
         return false;
       }

--- a/meals_app/pubspec.yaml
+++ b/meals_app/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   google_fonts: ^6.1.0
   transparent_image: ^2.0.1
-  riverpod: ^2.4.9
+  flutter_riverpod: ^2.4.9
 
 dev_dependencies:
   flutter_test:

--- a/quiz_app/lib/questions_screen.dart
+++ b/quiz_app/lib/questions_screen.dart
@@ -1,7 +1,6 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'dart:io';
 
 import 'package:quiz_app/data/questions.dart';
 import 'package:quiz_app/answer_button.dart';
@@ -36,7 +35,7 @@ class _QuestionsScreenState extends State<QuestionsScreen> {
         margin: const EdgeInsets.all(40),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
-          // crossAxisAlignment: CrossAxisAlignment.stretch,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Text(
               currentQuestion.text,
@@ -49,7 +48,7 @@ class _QuestionsScreenState extends State<QuestionsScreen> {
             const SizedBox(height: 30),
             ...currentQuestion.getShuffledAnswers().map(
               (answer) {
-                if (Platform.isAndroid || Platform.isIOS) {
+                if (Platform.isIOS || Platform.isIOS) {
                   return AnswerButton(
                     answerText: answer,
                     onTap: () {

--- a/quiz_app/lib/questions_screen.dart
+++ b/quiz_app/lib/questions_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
@@ -34,7 +36,7 @@ class _QuestionsScreenState extends State<QuestionsScreen> {
         margin: const EdgeInsets.all(40),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
+          // crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Text(
               currentQuestion.text,
@@ -47,12 +49,27 @@ class _QuestionsScreenState extends State<QuestionsScreen> {
             const SizedBox(height: 30),
             ...currentQuestion.getShuffledAnswers().map(
               (answer) {
-                return AnswerButton(
-                  answerText: answer,
-                  onTap: () {
-                    answerQuestion(answer);
-                  },
-                );
+                if (Platform.isAndroid || Platform.isIOS) {
+                  return AnswerButton(
+                    answerText: answer,
+                    onTap: () {
+                      answerQuestion(answer);
+                    },
+                  );
+                } else {
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      AnswerButton(
+                        answerText: answer,
+                        onTap: () {
+                          answerQuestion(answer);
+                        },
+                      ),
+                      const SizedBox(height: 5),
+                    ],
+                  );
+                }
               },
             ),
           ],


### PR DESCRIPTION
When running the app in macOs or windows, the questions would not have proper space between them:

<p align="center"><img width="500" alt="image" src="https://github.com/figredos/flutter/assets/101260213/8881964b-b205-479f-b170-c57015dc1d66"></p>

Implementing a simple if statement, where the platform is checked before rendering the answers allows a simple fix to this problem. If the platform is mobile (either IOS of Android) it render the button as it is, else it renders a Column widget containing the button and a SizedBox.

<p align="center"><img width="500" alt="image" src="https://github.com/figredos/flutter/assets/101260213/f2e311ff-dbde-41f7-8a83-13d4b62ad050"></p>


